### PR TITLE
Fix getBalances when return no result

### DIFF
--- a/lib/factories/wallet-factory.js
+++ b/lib/factories/wallet-factory.js
@@ -54,6 +54,9 @@ function WalletFactory (lemonway) {
     opts = opts || {};
     return lemonway._client.getBalances(ip, opts)
       .bind(this)
+      .then(function (wallets) {
+        return _.isArray(wallet) ? wallet : [];
+      })
       .map(function (data) {
         return new this.Wallet(data);
       });


### PR DESCRIPTION
When `lemonway._client.getBalances` return no result *wallets* = `{}` and fail with the `map()`