### PR TITLE
Allow to provide a string as sddMandateId

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -441,7 +441,9 @@ Client.prototype.registerSDDMandate = function (ip, _opts) {
 };
 
 Client.prototype.unregisterSDDMandate = function (ip, _opts) {
-  var opts = _.assign({}, _opts);
+  var opts = _.assign({}, _opts, {
+    sddMandateId: utils.stringToInteger(_opts.sddMandateId)
+  });
 
   return this._request('UnregisterSddMandate', ip, opts, 'UnRegisterSddMandateResult').get('SDDMANDATE');
 };
@@ -451,7 +453,8 @@ Client.prototype.moneyInSDDInit = function (ip, _opts) {
     amountTot: utils.numberToFixed(_opts.amount),
     amountCom: utils.numberToFixed(_opts.commission)
   }, _opts, {
-    autoCommission: utils.boolToString(_opts.autoCommission)
+    autoCommission: utils.boolToString(_opts.autoCommission),
+    sddMandateId: utils.stringToInteger(_opts.sddMandateId)
   });
 
   return this._request('MoneyInSddInit', ip, opts).get('TRANS').get('HPAY');

--- a/lib/factories/wallet-factory.js
+++ b/lib/factories/wallet-factory.js
@@ -33,7 +33,7 @@ function WalletFactory (lemonway) {
       });
     }
     if (_.get(data, 'SDDMANDATES')) {
-      this.sddMandates = _.map(_.get(data, 'SDDMANDATES'), function (sddMandate) {
+      this.sddMandates = _.map(_.get(data, 'SDDMANDATES.SDDMANDATE'), function (sddMandate) {
         return new SDDMandate(sddMandate);
       });
     }
@@ -80,7 +80,6 @@ function WalletFactory (lemonway) {
         return {
           wallet: new this.Wallet(data),
           documents: _.map(_.get(data, 'DOCS', []), function (data) { return new Document(data) }),
-          sddMandates: _.map(_.get(data, 'SDDMANDATES', []), function (data) { return new SDDMandate(data) }),
           creditCards: _.map(_.get(data, 'CARDS', []), function (data) { return new Card(data) })
         };
       });
@@ -96,7 +95,6 @@ function WalletFactory (lemonway) {
           wallet: new this.Wallet(data),
           documents: _.map(_.get(data, 'DOCS', []), function (data) { return new Document(data) }),
           ibans: _.map(_.get(data, 'IBANS', []), function (data) { return new IBAN(data) }),
-          sddMandates: _.map(_.get(data, 'SDDMANDATES', []), function (data) { return new SDDMandate(data) })
         };
       });
   };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,6 +24,10 @@ function boolToString (val) {
   return typeof val !== 'boolean' ? val : val ? '1' : '0';
 }
 
+function stringToInteger (val) {
+  return typeof val === 'string' ? parseInt(val, 10) : val;
+}
+
 function cardNumberToType (cardNumber) {
   var cardType = creditCardType(cardNumber);
   if (cardType.type && cardType.type[0] === 'visa') {
@@ -44,6 +48,7 @@ module.exports = {
   numberToFixed: numberToFixed,
   dateToUnix: dateToUnix,
   boolToString: boolToString,
+  stringToInteger: stringToInteger,
   cardNumberToType: cardNumberToType,
   getIp: getIp
 };

--- a/lib/validation-schemas.js
+++ b/lib/validation-schemas.js
@@ -251,7 +251,7 @@ Joi.UploadFile = function () {
     fileName: Joi.string().required(),
     type: Joi.string().required(),
     buffer: Joi.any().required(),
-    sddMandateId: Joi.number()
+    sddMandateId: Joi.alternatives().try(Joi.number(), Joi.string())
   }));
 };
 
@@ -335,7 +335,7 @@ Joi.RegisterSddMandate = function () {
 Joi.UnregisterSddMandate = function () {
   return Joi.lemonwayBase().concat(Joi.object({
     wallet: Joi.string().min(0).max(100).required(),
-    sddMandateId: Joi.number().required()
+    sddMandateId: Joi.alternatives().try(Joi.number(), Joi.string()).required()
   }));
 };
 
@@ -346,7 +346,7 @@ Joi.MoneyInSddInit = function () {
     amountCom: Joi.string(),
     comment: Joi.string(),
     autoCommission: Joi.string().valid(['0', '1']).required(),
-    sddMandateId: Joi.number().required(),
+    sddMandateId: Joi.alternatives().try(Joi.number(), Joi.string()).required(),
     collectionDate: Joi.date().format('dd/MM/yyyy')
   }));
 };

--- a/lib/validation-schemas.js
+++ b/lib/validation-schemas.js
@@ -347,7 +347,7 @@ Joi.MoneyInSddInit = function () {
     comment: Joi.string(),
     autoCommission: Joi.string().valid(['0', '1']).required(),
     sddMandateId: Joi.alternatives().try(Joi.number(), Joi.string()).required(),
-    collectionDate: Joi.date().format('dd/MM/yyyy')
+    collectionDate: Joi.date().format('DD/MM/YYYY')
   }));
 };
 


### PR DESCRIPTION
### Changes
- Convert `sddMandateId` to integer if a string is provided
- Fix getting `sddMandate` in Lemonway response, embed in `wallet` (not returned in root object)
- Fix `collectionDate` param format