### PR TITLE
Fix collectionDate format

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -462,7 +462,8 @@ Client.prototype.moneyInSDDInit = function (ip, _opts) {
     amountCom: utils.numberToFixed(_opts.commission)
   }, _opts, {
     autoCommission: utils.boolToString(_opts.autoCommission),
-    sddMandateId: utils.stringToInteger(_opts.sddMandateId)
+    sddMandateId: utils.stringToInteger(_opts.sddMandateId),
+    collectionDate: utils.dateToDayString(_opts.collectionDate)
   });
 
   return this._request('MoneyInSddInit', ip, opts).get('TRANS').get('HPAY');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,7 +17,11 @@ function numberToFixed (val, fixed) {
 }
 
 function dateToUnix (val) {
-  return val instanceof Date ? moment(val).unix() : val
+  return val instanceof Date ? moment(val).unix() : val;
+}
+
+function dateToDayString (val) {
+  return val instanceof Date ? moment(val).format('DD/MM/YYYY') : val;
 }
 
 function boolToString (val) {
@@ -47,6 +51,7 @@ module.exports = {
   remap: remap,
   numberToFixed: numberToFixed,
   dateToUnix: dateToUnix,
+  dateToDayString: dateToDayString,
   boolToString: boolToString,
   stringToInteger: stringToInteger,
   cardNumberToType: cardNumberToType,

--- a/lib/validation-schemas.js
+++ b/lib/validation-schemas.js
@@ -349,7 +349,7 @@ Joi.MoneyInSddInit = function () {
     comment: Joi.string(),
     autoCommission: Joi.string().valid(['0', '1']).required(),
     sddMandateId: Joi.alternatives().try(Joi.number(), Joi.string()).required(),
-    collectionDate: Joi.date().format('DD/MM/YYYY')
+    collectionDate: Joi.string()
   }));
 };
 


### PR DESCRIPTION
### Summary
In `MoneyInSddInit` call, the `collectionDate` should be a string, not a date (`Joi` casted the string into a Date object).

### Changes
- the method now accepts a date
- the conversion to string is done in the lib